### PR TITLE
修复windows下无法正确将路径分隔符替换成"."的bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ target/
 /dist/
 /nbdist/
 /.nb-gradle/
+.vscode

--- a/spring-toy-core/src/main/java/cn/bdqfork/core/utils/FileUtil.java
+++ b/spring-toy-core/src/main/java/cn/bdqfork/core/utils/FileUtil.java
@@ -1,0 +1,13 @@
+package cn.bdqfork.core.utils;
+
+import java.io.File;
+
+/**
+ * FileUtil
+ */
+public class FileUtil {
+
+    public static String getUniformAbsolutePath(File file) {
+        return file.getAbsolutePath().replaceAll("\\\\","\\/");
+    }
+}

--- a/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
+++ b/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
@@ -102,9 +102,5 @@ public class ReflectUtil {
         return classes;
     }
 
-    public static void main(String[] args) throws IOException {
-        JarFile file = new JarFile("C:/Users/h-l-j/Desktop/arduino-1.8.10-windows/arduino-1.8.10/lib/batik-ext-1.8.jar");
-        getClassesByJar(file);
-    }
 
 }

--- a/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
+++ b/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
@@ -68,6 +68,7 @@ public class ReflectUtil {
             String path = chirldFile.getAbsolutePath();
             if (!chirldFile.isDirectory() && path.endsWith(SUFFIX)) {
                 String className = path.substring(path.indexOf(packagePath), path.lastIndexOf(SUFFIX))
+                        .replaceAll("\\\\","\\/")
                         .replaceAll("/", ".");
                 try {
                     Class clazz = Class.forName(className);
@@ -91,6 +92,7 @@ public class ReflectUtil {
                 String entryName = jarEntry.getName();
                 if (!jarEntry.isDirectory() && entryName.endsWith(SUFFIX)) {
                     String className = entryName.substring(0, entryName.lastIndexOf(SUFFIX))
+                            .replaceAll("\\\\","\\/")
                             .replaceAll("/", ".");
                     Class clazz = Class.forName(className);
                     classes.add(clazz);

--- a/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
+++ b/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
@@ -65,7 +65,7 @@ public class ReflectUtil {
             return classes;
         }
         for (File chirldFile : chirldFiles) {
-            String path = chirldFile.getAbsolutePath().replaceAll("\\\\","\\/");
+            String path = FileUtil.getUniformAbsolutePath(chirldFile);
             if (!chirldFile.isDirectory() && path.endsWith(SUFFIX)) {
                 String className = path.substring(path.indexOf(packagePath), path.lastIndexOf(SUFFIX))
                         .replaceAll("/", ".");
@@ -91,7 +91,6 @@ public class ReflectUtil {
                 String entryName = jarEntry.getName();
                 if (!jarEntry.isDirectory() && entryName.endsWith(SUFFIX)) {
                     String className = entryName.substring(0, entryName.lastIndexOf(SUFFIX))
-                            .replaceAll("\\\\","\\/")
                             .replaceAll("/", ".");
                     Class clazz = Class.forName(className);
                     classes.add(clazz);
@@ -101,6 +100,11 @@ public class ReflectUtil {
             e.printStackTrace();
         }
         return classes;
+    }
+
+    public static void main(String[] args) throws IOException {
+        JarFile file = new JarFile("C:/Users/h-l-j/Desktop/arduino-1.8.10-windows/arduino-1.8.10/lib/batik-ext-1.8.jar");
+        getClassesByJar(file);
     }
 
 }

--- a/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
+++ b/spring-toy-core/src/main/java/cn/bdqfork/core/utils/ReflectUtil.java
@@ -65,10 +65,9 @@ public class ReflectUtil {
             return classes;
         }
         for (File chirldFile : chirldFiles) {
-            String path = chirldFile.getAbsolutePath();
+            String path = chirldFile.getAbsolutePath().replaceAll("\\\\","\\/");
             if (!chirldFile.isDirectory() && path.endsWith(SUFFIX)) {
                 String className = path.substring(path.indexOf(packagePath), path.lastIndexOf(SUFFIX))
-                        .replaceAll("\\\\","\\/")
                         .replaceAll("/", ".");
                 try {
                     Class clazz = Class.forName(className);


### PR DESCRIPTION
由于File.getAbsolutePath()在windows下获取的路径采用"\"分割，所以仅仅通过replaceAll("/", ".")无法正确转化为包名，故先通过replaceAll("\\\\","\\/")将windows特有的"\"转化为"/"后再作处理